### PR TITLE
Fix missing callback action error

### DIFF
--- a/lib/lockup.rb
+++ b/lib/lockup.rb
@@ -7,9 +7,9 @@ module Lockup
 
   included do
     if respond_to?(:before_action)
-      before_action :check_for_lockup, except: ['unlock']
+      before_action :check_for_lockup
     else
-      before_filter :check_for_lockup, except: ['unlock']
+      before_filter :check_for_lockup
     end
   end
 


### PR DESCRIPTION
Using the library with Rails 7.1 currently results in this error:
> The unlock action could not be found for the :check_for_lockup callback on SomeController, but it is listed in the controller's :except option. 
>
> Raising for missing callback actions is a new default in Rails 7.1, if you'd like to turn this off you can delete the option from the environment configurations or set `config.action_controller.raise_on_missing_callback_actions` to `false`.

This is because the unlock action does not exist in my applications controllers, nor should I add the unlock action to those controllers.

The LockupController responsible for unlocking already has a skip_before_action/filter call and means the exception was unnecessary.
https://github.com/interdiscipline/lockup/blob/86d9955b7600dafd89ad2d47a012ebd95ede8af1/app/controllers/lockup/lockup_controller.rb#L5-L9

